### PR TITLE
feat: output better error message when token is not set

### DIFF
--- a/app/Commands/BrokenLinkShowCommand.php
+++ b/app/Commands/BrokenLinkShowCommand.php
@@ -2,11 +2,11 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
-use Illuminate\Support\Collection;
-use OhDear\PhpSdk\Resources\BrokenLink;
 use App\Commands\Concerns\EnsureHasToken;
+use Illuminate\Support\Collection;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
+use OhDear\PhpSdk\Resources\BrokenLink;
 
 class BrokenLinkShowCommand extends Command
 {

--- a/app/Commands/BrokenLinkShowCommand.php
+++ b/app/Commands/BrokenLinkShowCommand.php
@@ -2,21 +2,28 @@
 
 namespace App\Commands;
 
-use Illuminate\Support\Collection;
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use Illuminate\Support\Collection;
 use OhDear\PhpSdk\Resources\BrokenLink;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class BrokenLinkShowCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'broken-link:show {site-id : The id of the site to view broken links for}';
 
     /** @var string */
     protected $description = 'Display the broken links for a site';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $brokenLinks = $ohDear->brokenLinks($this->argument('site-id'));
 
         if (empty($brokenLinks)) {

--- a/app/Commands/CertificateHealthShowCommand.php
+++ b/app/Commands/CertificateHealthShowCommand.php
@@ -2,11 +2,14 @@
 
 namespace App\Commands;
 
+use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
 
 class CertificateHealthShowCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'certificate-health:show {site-id : The id of the site to view certificate health for}
                                                     {--c|checks : Include a list of the certificate checks that were performed}
@@ -15,8 +18,12 @@ class CertificateHealthShowCommand extends Command
     /** @var string */
     protected $description = 'Display the certificate health for a site';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $certificateHealth = $ohDear->certificateHealth($this->argument('site-id'));
 
         $this->output->text([

--- a/app/Commands/Concerns/EnsureHasToken.php
+++ b/app/Commands/Concerns/EnsureHasToken.php
@@ -13,6 +13,7 @@ trait EnsureHasToken
     {
         if (! $this->hasToken()) {
             $this->error('You have not configured your Oh Dear API token yet. Please set the `OHDEAR_API_TOKEN` environment variable first.');
+
             return false;
         }
 

--- a/app/Commands/Concerns/EnsureHasToken.php
+++ b/app/Commands/Concerns/EnsureHasToken.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Commands\Concerns;
+
+trait EnsureHasToken
+{
+    protected function hasToken()
+    {
+        return config('settings.ohdear_api_token') !== null && config('settings.ohdear_api_token') !== '';
+    }
+
+    protected function ensureHasToken()
+    {
+        if (! $this->hasToken()) {
+            $this->error('You have not configured your Oh Dear API token yet. Please set the `OHDEAR_API_TOKEN` environment variable first.');
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Commands/MaintenancePeriodAddCommand.php
+++ b/app/Commands/MaintenancePeriodAddCommand.php
@@ -2,11 +2,14 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class MaintenancePeriodAddCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'maintenance-period:add
                             {site-id : The id of the site that you want to create a maintenance period for}
@@ -16,8 +19,12 @@ class MaintenancePeriodAddCommand extends Command
     /** @var string */
     protected $description = 'Add a new maintenance period for a site';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         if (! $startDate = $this->argument('start-date')) {
             $this->warn('A valid start date must be provided');
 

--- a/app/Commands/MaintenancePeriodAddCommand.php
+++ b/app/Commands/MaintenancePeriodAddCommand.php
@@ -2,9 +2,9 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
 use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 
 class MaintenancePeriodAddCommand extends Command
 {

--- a/app/Commands/MaintenancePeriodDeleteCommand.php
+++ b/app/Commands/MaintenancePeriodDeleteCommand.php
@@ -2,11 +2,14 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class MaintenancePeriodDeleteCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'maintenance-period:delete
                             {id : The id of the maintenance period that you want to delete}';
@@ -14,8 +17,12 @@ class MaintenancePeriodDeleteCommand extends Command
     /** @var string */
     protected $description = 'Delete a maintenance period';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $ohDear->deleteSiteMaintenance($this->argument('id'));
 
         $this->info("Removed the maintenance period with id {$this->argument('id')}");

--- a/app/Commands/MaintenancePeriodDeleteCommand.php
+++ b/app/Commands/MaintenancePeriodDeleteCommand.php
@@ -2,9 +2,9 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
 use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 
 class MaintenancePeriodDeleteCommand extends Command
 {

--- a/app/Commands/MaintenancePeriodShowCommand.php
+++ b/app/Commands/MaintenancePeriodShowCommand.php
@@ -2,20 +2,27 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\Resources\MaintenancePeriod;
 
 class MaintenancePeriodShowCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'maintenance-period:show {site-id : The id of the site to view maintenance periods for}';
 
     /** @var string */
     protected $description = 'Display the maintenance periods for a site';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $maintenancePeriods = $ohDear->maintenancePeriods($this->argument('site-id'));
 
         if (empty($maintenancePeriods)) {

--- a/app/Commands/MaintenancePeriodShowCommand.php
+++ b/app/Commands/MaintenancePeriodShowCommand.php
@@ -2,9 +2,9 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
 use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 use OhDear\PhpSdk\Resources\MaintenancePeriod;
 
 class MaintenancePeriodShowCommand extends Command

--- a/app/Commands/MaintenancePeriodStartCommand.php
+++ b/app/Commands/MaintenancePeriodStartCommand.php
@@ -2,11 +2,14 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class MaintenancePeriodStartCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'maintenance-period:start
                             {site-id : The id of the site that you want to create a maintenance period for}
@@ -15,8 +18,12 @@ class MaintenancePeriodStartCommand extends Command
     /** @var string */
     protected $description = 'Start a new maintenance period for a site from the current time';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $seconds = $this->argument('seconds');
 
         if (! $seconds || ! is_numeric($seconds)) {

--- a/app/Commands/MaintenancePeriodStartCommand.php
+++ b/app/Commands/MaintenancePeriodStartCommand.php
@@ -2,9 +2,9 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
 use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 
 class MaintenancePeriodStartCommand extends Command
 {

--- a/app/Commands/MaintenancePeriodStopCommand.php
+++ b/app/Commands/MaintenancePeriodStopCommand.php
@@ -2,9 +2,9 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
 use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 
 class MaintenancePeriodStopCommand extends Command
 {

--- a/app/Commands/MaintenancePeriodStopCommand.php
+++ b/app/Commands/MaintenancePeriodStopCommand.php
@@ -2,11 +2,14 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class MaintenancePeriodStopCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'maintenance-period:stop
                             {site-id : The id of the site that you want to stop the maintenance period for}';
@@ -14,8 +17,12 @@ class MaintenancePeriodStopCommand extends Command
     /** @var string */
     protected $description = 'Stop the current maintenance period for a site';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $ohDear->stopSiteMaintenance($this->argument('site-id'));
 
         $this->info("Stopped the current maintenance period for site with id {$this->argument('site-id')}");

--- a/app/Commands/MeCommand.php
+++ b/app/Commands/MeCommand.php
@@ -2,20 +2,27 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
 use OhDear\PhpSdk\Resources\Team;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class MeCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'me';
 
     /** @var string */
     protected $description = 'Display information about the currently authenticated user';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $data = $ohDear->me();
 
         $this->output->text([

--- a/app/Commands/MeCommand.php
+++ b/app/Commands/MeCommand.php
@@ -2,10 +2,10 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
-use OhDear\PhpSdk\Resources\Team;
 use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
+use OhDear\PhpSdk\Resources\Team;
 
 class MeCommand extends Command
 {

--- a/app/Commands/MixedContentShowCommand.php
+++ b/app/Commands/MixedContentShowCommand.php
@@ -2,10 +2,10 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
-use Illuminate\Support\Collection;
 use App\Commands\Concerns\EnsureHasToken;
+use Illuminate\Support\Collection;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 use OhDear\PhpSdk\Resources\MixedContentItem;
 
 class MixedContentShowCommand extends Command

--- a/app/Commands/MixedContentShowCommand.php
+++ b/app/Commands/MixedContentShowCommand.php
@@ -2,21 +2,28 @@
 
 namespace App\Commands;
 
-use Illuminate\Support\Collection;
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use Illuminate\Support\Collection;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\Resources\MixedContentItem;
 
 class MixedContentShowCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'mixed-content:show {site-id : The id of the site to view mixed content for}';
 
     /** @var string */
     protected $description = 'Display the mixed content for a site';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $mixedContents = $ohDear->mixedContent($this->argument('site-id'));
 
         if (empty($mixedContents)) {

--- a/app/Commands/PerformanceShowCommand.php
+++ b/app/Commands/PerformanceShowCommand.php
@@ -3,11 +3,14 @@
 namespace App\Commands;
 
 use Carbon\Carbon;
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class PerformanceShowCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'performance:show {id : The id of the status page to view}
                                              {start-date? : The date to start at}
@@ -20,6 +23,10 @@ class PerformanceShowCommand extends Command
 
     public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         if (! $startDate = $this->argument('start-date')) {
             $startDate = Carbon::yesterday()->format('Y-m-d');
         }

--- a/app/Commands/PerformanceShowCommand.php
+++ b/app/Commands/PerformanceShowCommand.php
@@ -2,10 +2,10 @@
 
 namespace App\Commands;
 
-use Carbon\Carbon;
-use OhDear\PhpSdk\OhDear;
 use App\Commands\Concerns\EnsureHasToken;
+use Carbon\Carbon;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 
 class PerformanceShowCommand extends Command
 {

--- a/app/Commands/SitesAddCommand.php
+++ b/app/Commands/SitesAddCommand.php
@@ -2,11 +2,14 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class SitesAddCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'sites:add
                             {url : The url of the site that you want to add}
@@ -16,8 +19,12 @@ class SitesAddCommand extends Command
     /** @var string */
     protected $description = 'Add a new site to Oh Dear';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         if (! ($url = $this->argument('url'))) {
             $this->warn('A valid URL must be provided');
 

--- a/app/Commands/SitesAddCommand.php
+++ b/app/Commands/SitesAddCommand.php
@@ -2,9 +2,9 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
 use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 
 class SitesAddCommand extends Command
 {

--- a/app/Commands/SitesListCommand.php
+++ b/app/Commands/SitesListCommand.php
@@ -2,20 +2,27 @@
 
 namespace App\Commands;
 
-use Illuminate\Support\Collection;
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use Illuminate\Support\Collection;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class SitesListCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'sites:list';
 
     /** @var string */
     protected $description = 'Display a list of sites and their current status';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $siteData = Collection::make($ohDear->sites())->map(static function ($site) {
             return [
                 $site->id,

--- a/app/Commands/SitesListCommand.php
+++ b/app/Commands/SitesListCommand.php
@@ -2,10 +2,10 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
-use Illuminate\Support\Collection;
 use App\Commands\Concerns\EnsureHasToken;
+use Illuminate\Support\Collection;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 
 class SitesListCommand extends Command
 {

--- a/app/Commands/SitesShowCommand.php
+++ b/app/Commands/SitesShowCommand.php
@@ -2,10 +2,10 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
-use OhDear\PhpSdk\Resources\Check;
 use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
+use OhDear\PhpSdk\Resources\Check;
 
 class SitesShowCommand extends Command
 {

--- a/app/Commands/SitesShowCommand.php
+++ b/app/Commands/SitesShowCommand.php
@@ -2,27 +2,34 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
 use OhDear\PhpSdk\Resources\Check;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class SitesShowCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'sites:show {id : The id of the site to view}';
 
     /** @var string */
     protected $description = 'Display a single site and its current status';
 
-    public function handle(OhDear $ohDear): void
+    public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $site = $ohDear->site($this->argument('id'));
 
         $uptimePercentage = $site->uptime(
-                now()->subDay()->format('YmdHis'),
-                now()->format('YmdHis'),
-                'day'
-            )[0]->uptimePercentage ?? 'unknown';
+            now()->subDay()->format('YmdHis'),
+            now()->format('YmdHis'),
+            'day'
+        )[0]->uptimePercentage ?? 'unknown';
 
         $this->output->text([
             "<options=bold>ID:</> {$site->id}",

--- a/app/Commands/StatusPagesListCommand.php
+++ b/app/Commands/StatusPagesListCommand.php
@@ -2,10 +2,10 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
-use Illuminate\Support\Collection;
 use App\Commands\Concerns\EnsureHasToken;
+use Illuminate\Support\Collection;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 
 class StatusPagesListCommand extends Command
 {

--- a/app/Commands/StatusPagesListCommand.php
+++ b/app/Commands/StatusPagesListCommand.php
@@ -2,12 +2,15 @@
 
 namespace App\Commands;
 
-use Illuminate\Support\Collection;
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use Illuminate\Support\Collection;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class StatusPagesListCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'status-pages:list';
 
@@ -16,6 +19,10 @@ class StatusPagesListCommand extends Command
 
     public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $statusPageData = Collection::make($ohDear->statusPages())->map(static function ($statusPage) {
             return [
                 $statusPage->id,

--- a/app/Commands/StatusPagesShowCommand.php
+++ b/app/Commands/StatusPagesShowCommand.php
@@ -2,9 +2,9 @@
 
 namespace App\Commands;
 
-use OhDear\PhpSdk\OhDear;
 use App\Commands\Concerns\EnsureHasToken;
 use LaravelZero\Framework\Commands\Command;
+use OhDear\PhpSdk\OhDear;
 
 class StatusPagesShowCommand extends Command
 {

--- a/app/Commands/StatusPagesShowCommand.php
+++ b/app/Commands/StatusPagesShowCommand.php
@@ -2,11 +2,14 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
 use OhDear\PhpSdk\OhDear;
+use App\Commands\Concerns\EnsureHasToken;
+use LaravelZero\Framework\Commands\Command;
 
 class StatusPagesShowCommand extends Command
 {
+    use EnsureHasToken;
+
     /** @var string */
     protected $signature = 'status-pages:show {id : The id of the status page to view}';
 
@@ -15,6 +18,10 @@ class StatusPagesShowCommand extends Command
 
     public function handle(OhDear $ohDear)
     {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
         $statusPage = $ohDear->statusPage($this->argument('id'));
 
         $this->output->text([

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,18 +4,13 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use OhDear\PhpSdk\OhDear;
-use RuntimeException;
 
 class AppServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
         $this->app->singleton(OhDear::class, function () {
-            if (! $apiToken = config('settings.ohdear_api_token')) {
-                throw new RuntimeException('Oh Dear API key not set');
-            }
-
-            return new OhDear($apiToken);
+            return new OhDear(config('settings.ohdear_api_token'));
         });
     }
 


### PR DESCRIPTION
This ensures that a proper error message is output on all commands where a token is not set, rather than an exception.