### PR TITLE
ci: add workflow to release PHAR on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  phar-release:
+    name: PHAR
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Create GitHub Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+
+    - name: Upload PHAR
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./builds/ohdear-cli
+        asset_name: ohdear-cli.phar
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
Debating whether to sign the PHAR with a subkey, and upload the `.asc` to the releases as well. That way, people can install via [Phive](https://phar.io) without requiring the `--force-accept-unsigned` flag.

With this workflow, PHAR files would be uploaded to GitHub Releases on tag, allowing for installs via Phive with:

```bash
phive install --force-accept-unsigned nunomaduro/ohdear-cli
```